### PR TITLE
fix: Support multi-line formulas in generated model classes

### DIFF
--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -61,6 +61,7 @@ class TablePyFileWriter(PyFileWriter):
     def add_table_class_decl(self, table_ident, table_id, app_var_name):
         class_name = make_var_name(table_ident, case='pascal')
         self.pyfile\
+            .space()\
             .add_line(f'class {class_name}(QuickBaseTable):')\
             .indent()\
             .add_line(f"__dbid__ = '{table_id}'")\
@@ -82,7 +83,7 @@ class TablePyFileWriter(PyFileWriter):
         formula_str = ''
         if properties['formula'] != '':
             self.formula_outlet\
-                .add_line(f"{var_name}_formula = '{properties['formula']}'")\
+                .add_line(f"{var_name}_formula = '''{properties['formula']}'''")\
                 .space()
             formula_str = f', formula={var_name}_formula'
 

--- a/tests/data/mocks/get_fields_for_table_bbbbbb.json
+++ b/tests/data/mocks/get_fields_for_table_bbbbbb.json
@@ -52,7 +52,7 @@
       "maxLength": 0,
       "appendOnly": false,
       "allowHTML": false,
-      "formula": "[Description]",
+      "formula": "var text desc = [Description];\n\n$desc",
       "defaultValue": ""
     }
   },

--- a/tests/test_tools/test_model_generate.py
+++ b/tests/test_tools/test_model_generate.py
@@ -88,7 +88,8 @@ class TestModelGenerator:
         gen = run_generator()
         m = gen.pkg_writer.modules['idea']
         s = m.get_file_as_string()
-        assert '[Description]' in s
+        assert "'''var text desc = [Description]" in s
+        assert "$desc'''" in s
         assert 'formula=' in s
 
     def test_script_args(self, monkeypatch, run_generator):


### PR DESCRIPTION
## Description

This PR closes #38 by wrapping formula definitions in triple quotes (`'''`). It also adds an extra new line before the class declaration.

**Checklist:**

- [x] Submitting to `dev` branch
- [x] pytest tests passing
- [x] Includes tests to cover the changes
- [x] flake8 passing
- [x] Relevant documentation added
