### PR TITLE
feat: Add `--tbl-obj` argument to the `model-generate` script

### DIFF
--- a/docs/source/cli_tools/index.rst
+++ b/docs/source/cli_tools/index.rst
@@ -44,6 +44,6 @@ Running ``model-generate`` you can pass your user token on the command line or s
       -t [USER_TOK], --user-tok [USER_TOK]
                             the user token to authenticate - if not provided will read from
                             environment variable QB_USER_TOKEN
-      -o [TBL_OBJ], --tbl-obj [TBL_OBJ]
-                            ID or name of a table to generate - can be specified
-                            multiple times
+      -i [INCLUDE], --include [INCLUDE]
+                            ID or name of a table to include - can be specified
+                            multiple times; if present, excludes all other tables

--- a/docs/source/cli_tools/index.rst
+++ b/docs/source/cli_tools/index.rst
@@ -44,4 +44,6 @@ Running ``model-generate`` you can pass your user token on the command line or s
       -t [USER_TOK], --user-tok [USER_TOK]
                             the user token to authenticate - if not provided will read from
                             environment variable QB_USER_TOKEN
-
+      -o [TBL_OBJ], --tbl-obj [TBL_OBJ]
+                            ID or name of a table to generate - can be specified
+                            multiple times

--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -3,7 +3,7 @@ import sys
 from typing import Optional
 
 from quickbase_client.client.api import QuickBaseApiClient
-from quickbase_client.orm.field import get_field_type_by_string, get_field_type_hint
+from quickbase_client.orm.field import get_field_type_by_string
 from quickbase_client.tools.script import Script
 from quickbase_client.utils.pywriting_utils import BasicPyFileWriter
 from quickbase_client.utils.pywriting_utils import PyFileWriter
@@ -49,9 +49,6 @@ class TablePyFileWriter(PyFileWriter):
         self.pyfile\
             .add_comment(f'{file_name}.py - QuickBaseTable for {table_name}')\
             .space()\
-            .add_line('from datetime import datetime, date')\
-            .add_line('from typing import Any')\
-            .space()\
             .add_line('from quickbase_client import QuickBaseField')\
             .add_line('from quickbase_client import QuickBaseFieldType as Qb')\
             .add_line('# from quickbase_client import QuickBaseReport')\
@@ -69,11 +66,11 @@ class TablePyFileWriter(PyFileWriter):
             .add_line(f"__dbid__ = '{table_id}'")\
             .add_line(f'__app__ = {app_var_name}')\
             .space()\
-            .add_line('date_created: datetime = QuickBaseField(fid=1, field_type=Qb.DATETIME)')\
-            .add_line('date_modified: datetime = QuickBaseField(fid=2, field_type=Qb.DATETIME)')\
-            .add_line('recordid: int = QuickBaseField(fid=3, field_type=Qb.NUMERIC)')\
-            .add_line('record_owner: Any = QuickBaseField(fid=4, field_type=Qb.USER)')\
-            .add_line('last_modified: Any = QuickBaseField(fid=5, field_type=Qb.USER)')\
+            .add_line('date_created = QuickBaseField(fid=1, field_type=Qb.DATETIME)')\
+            .add_line('date_modified = QuickBaseField(fid=2, field_type=Qb.DATETIME)')\
+            .add_line('recordid = QuickBaseField(fid=3, field_type=Qb.NUMERIC)')\
+            .add_line('record_owner = QuickBaseField(fid=4, field_type=Qb.USER)')\
+            .add_line('last_modified = QuickBaseField(fid=5, field_type=Qb.USER)')\
             .space()
 
     def add_table_field(self, field_name, field_id, field_kind, properties):
@@ -81,7 +78,6 @@ class TablePyFileWriter(PyFileWriter):
             return  # the special reserved ones already accounted for more or less.
         var_name = make_unique_var_name(field_name, taken=self.field_vars)
         field_kind = str(get_field_type_by_string(field_kind)).split('.')[1]
-        type_hint = get_field_type_hint(field_kind, field_id, False)
 
         formula_str = ''
         if properties['formula'] != '':
@@ -91,7 +87,7 @@ class TablePyFileWriter(PyFileWriter):
             formula_str = f', formula={var_name}_formula'
 
         self.pyfile\
-            .add_line(f'{var_name}: {type_hint} = QuickBaseField('
+            .add_line(f'{var_name} = QuickBaseField('
                       f'fid={field_id}, '
                       f'field_type=Qb.{field_kind}{formula_str})')
 

--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -3,7 +3,7 @@ import sys
 from typing import Optional
 
 from quickbase_client.client.api import QuickBaseApiClient
-from quickbase_client.orm.field import get_field_type_by_string
+from quickbase_client.orm.field import get_field_type_by_string, get_field_type_hint
 from quickbase_client.tools.script import Script
 from quickbase_client.utils.pywriting_utils import BasicPyFileWriter
 from quickbase_client.utils.pywriting_utils import PyFileWriter
@@ -49,6 +49,9 @@ class TablePyFileWriter(PyFileWriter):
         self.pyfile\
             .add_comment(f'{file_name}.py - QuickBaseTable for {table_name}')\
             .space()\
+            .add_line('from datetime import datetime, date')\
+            .add_line('from typing import Any')\
+            .space()\
             .add_line('from quickbase_client import QuickBaseField')\
             .add_line('from quickbase_client import QuickBaseFieldType as Qb')\
             .add_line('# from quickbase_client import QuickBaseReport')\
@@ -66,11 +69,11 @@ class TablePyFileWriter(PyFileWriter):
             .add_line(f"__dbid__ = '{table_id}'")\
             .add_line(f'__app__ = {app_var_name}')\
             .space()\
-            .add_line('date_created = QuickBaseField(fid=1, field_type=Qb.DATETIME)')\
-            .add_line('date_modified = QuickBaseField(fid=2, field_type=Qb.DATETIME)')\
-            .add_line('recordid = QuickBaseField(fid=3, field_type=Qb.NUMERIC)')\
-            .add_line('record_owner = QuickBaseField(fid=4, field_type=Qb.USER)')\
-            .add_line('last_modified = QuickBaseField(fid=5, field_type=Qb.USER)')\
+            .add_line('date_created: datetime = QuickBaseField(fid=1, field_type=Qb.DATETIME)')\
+            .add_line('date_modified: datetime = QuickBaseField(fid=2, field_type=Qb.DATETIME)')\
+            .add_line('recordid: int = QuickBaseField(fid=3, field_type=Qb.NUMERIC)')\
+            .add_line('record_owner: Any = QuickBaseField(fid=4, field_type=Qb.USER)')\
+            .add_line('last_modified: Any = QuickBaseField(fid=5, field_type=Qb.USER)')\
             .space()
 
     def add_table_field(self, field_name, field_id, field_kind, properties):
@@ -78,6 +81,7 @@ class TablePyFileWriter(PyFileWriter):
             return  # the special reserved ones already accounted for more or less.
         var_name = make_unique_var_name(field_name, taken=self.field_vars)
         field_kind = str(get_field_type_by_string(field_kind)).split('.')[1]
+        type_hint = get_field_type_hint(field_kind, field_id, False)
 
         formula_str = ''
         if properties['formula'] != '':
@@ -87,7 +91,7 @@ class TablePyFileWriter(PyFileWriter):
             formula_str = f', formula={var_name}_formula'
 
         self.pyfile\
-            .add_line(f'{var_name} = QuickBaseField('
+            .add_line(f'{var_name}: {type_hint} = QuickBaseField('
                       f'fid={field_id}, '
                       f'field_type=Qb.{field_kind}{formula_str})')
 
@@ -128,9 +132,9 @@ class ModelGenerator(Script):
         parser.add_argument('-t', '--user-tok', nargs='?', default=None,
                             help='the user token to authenticate - if not provided will read from '
                                  'environment variable QB_USER_TOKEN')
-        parser.add_argument('-o', '--tbl-obj', nargs='?', default=None, action='append',
-                            help='ID or name of a table to generate - can be specified '
-                                 'multiple times')
+        parser.add_argument('-i', '--include', nargs='?', default=None, action='append',
+                            help='ID or name of a table to include in generation - can be specified '
+                                 'multiple times; if present, excludes all other tables')
 
     @staticmethod
     def instantiate_from_ns(ns) -> 'Script':
@@ -138,7 +142,7 @@ class ModelGenerator(Script):
         try:
             user_tok = ns.user_tok if ns.user_tok is not None else os.environ['QB_USER_TOKEN']
             return ModelGenerator(realm_hostname, app_id, user_token=user_tok, pkg_dir=ns.pkg_dir,
-                                  table_ids=ns.tbl_obj)
+                                  table_ids=ns.include)
         except (KeyError, OSError):
             raise EnvironmentError('ERROR: expected either a -t argument or a '
                                    'QB_USER_TOKEN environment variable')

--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -133,7 +133,7 @@ class ModelGenerator(Script):
                             help='the user token to authenticate - if not provided will read from '
                                  'environment variable QB_USER_TOKEN')
         parser.add_argument('-i', '--include', nargs='?', default=None, action='append',
-                            help='ID or name of a table to include in generation - can be specified '
+                            help='ID or name of a table to include - can be specified '
                                  'multiple times; if present, excludes all other tables')
 
     @staticmethod
@@ -164,8 +164,8 @@ class ModelGenerator(Script):
     def add_table_file(self, table, fields):
         table_ident = table['singleRecordName']
         file_name = make_var_name(table_ident)
-        if len(self.table_ids) and not (
-            table_ident in self.table_ids or file_name in self.table_ids or table['id'] in self.table_ids # noqa
+        if len(self.table_ids) and not any(
+            x in self.table_ids for x in [table_ident, file_name, table['id']]
         ):
             # if table_ids have been specified, and this table's ID, single record name, or var name
             # is not in the list, skip it

--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -101,13 +101,14 @@ class TablePyFileWriter(PyFileWriter):
 class ModelGenerator(Script):
     registration_name = 'model-generate'
 
-    def __init__(self, realm_hostname, app_id, user_token, pkg_dir=None):
+    def __init__(self, realm_hostname, app_id, user_token, pkg_dir=None, table_ids=None):
         self.realm_hostname = realm_hostname
         self.app_id = app_id
         self.user_token = user_token
         self.app_var_name = None
         self.table_vars = {}
         self.pkg_import_stmt = ''
+        self.table_ids = table_ids if table_ids else []
 
         if pkg_dir is None:
             models_pkg = PyPackageWriter(pkg_name='models', parent_dir=os.getcwd())
@@ -125,15 +126,19 @@ class ModelGenerator(Script):
         parser.add_argument('-d', '--pkg-dir', nargs='?', default=None,
                             help='the directory to put the package in, defaults to "models"')
         parser.add_argument('-t', '--user-tok', nargs='?', default=None,
-                            help='the user token to authenticate - if not provided will read from'
+                            help='the user token to authenticate - if not provided will read from '
                                  'environment variable QB_USER_TOKEN')
+        parser.add_argument('-o', '--tbl-obj', nargs='?', default=None, action='append',
+                            help='ID or name of a table to generate - can be specified '
+                                 'multiple times')
 
     @staticmethod
     def instantiate_from_ns(ns) -> 'Script':
         realm_hostname, app_id = parse_realm_and_app_id_from_url(ns.app_url)
         try:
             user_tok = ns.user_tok if ns.user_tok is not None else os.environ['QB_USER_TOKEN']
-            return ModelGenerator(realm_hostname, app_id, user_token=user_tok, pkg_dir=ns.pkg_dir)
+            return ModelGenerator(realm_hostname, app_id, user_token=user_tok, pkg_dir=ns.pkg_dir,
+                                  table_ids=ns.tbl_obj)
         except (KeyError, OSError):
             raise EnvironmentError('ERROR: expected either a -t argument or a '
                                    'QB_USER_TOKEN environment variable')
@@ -155,6 +160,12 @@ class ModelGenerator(Script):
     def add_table_file(self, table, fields):
         table_ident = table['singleRecordName']
         file_name = make_var_name(table_ident)
+        if len(self.table_ids) and not (
+            table_ident in self.table_ids or file_name in self.table_ids or table['id'] in self.table_ids # noqa
+        ):
+            # if table_ids have been specified, and this table's ID, single record name, or var name
+            # is not in the list, skip it
+            return
         if file_name in self.pkg_writer.modules:
             table_ident = table['alias'].replace('_DBID_', '')
             file_name = make_var_name(table_ident)

--- a/tests/test_tools/test_model_generate.py
+++ b/tests/test_tools/test_model_generate.py
@@ -59,7 +59,6 @@ class TestModelGenerator:
 
     def test_creates_table_files(self, run_generator):
         def _asserts(d, _):
-            print(os.listdir(os.path.join(d, 'qbcpy')))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'debug.py'))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'idea.py'))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'ideas_2.py'))

--- a/tests/test_tools/test_model_generate.py
+++ b/tests/test_tools/test_model_generate.py
@@ -11,11 +11,11 @@ from quickbase_client.tools.model_generate import ModelGenerator
 
 @pytest.fixture()
 def run_generator(qb_api_mock, monkeypatch):
-    def _post_run_generator(f=lambda d, run_result: None):
+    def _post_run_generator(f=lambda d, run_result: None, **kwargs: None):
         with TemporaryDirectory() as d:
             monkeypatch.setattr(model_generate.os, 'getcwd', lambda: d)
             gen = ModelGenerator(realm_hostname='example.quickbase.com', app_id='abcdef',
-                                 user_token='foo', pkg_dir=d)
+                                 user_token='foo', pkg_dir=d, **kwargs)
             run_result = gen.run()
             f(d, run_result)
         return gen
@@ -59,9 +59,18 @@ class TestModelGenerator:
 
     def test_creates_table_files(self, run_generator):
         def _asserts(d, _):
+            print(os.listdir(os.path.join(d, 'qbcpy')))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'debug.py'))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'idea.py'))
+            assert os.path.exists(os.path.join(d, 'qbcpy', 'ideas_2.py'))
         run_generator(_asserts)
+
+    def test_creates_only_requested_table_files(self, run_generator):
+        def _asserts(d, _):
+            assert not os.path.exists(os.path.join(d, 'qbcpy', 'debug.py'))
+            assert os.path.exists(os.path.join(d, 'qbcpy', 'idea.py'))
+            assert os.path.exists(os.path.join(d, 'qbcpy', 'ideas_2.py'))
+        run_generator(_asserts, table_ids=['idea', 'cccccc'])
 
     def test_writes_table_class(self, run_generator):
         gen = run_generator()
@@ -103,6 +112,23 @@ class TestModelGenerator:
             assert c.realm_hostname == 'example.quickbase.com'
             assert c.app_id == 'abcdef'
             assert c.user_token == 'whocares'
+            assert c.table_ids == []
+
+    def test_script_args_accepts_table_ids(self, monkeypatch):
+        def _intercept_run(self_):
+            return self_
+        monkeypatch.setattr(ModelGenerator, 'run', _intercept_run)
+
+        with TemporaryDirectory() as d:
+            monkeypatch.setattr(model_generate.os, 'getcwd', lambda: d)
+            c = qbc.main(['run', 'model-generate', '--app-url',
+                          'https://example.quickbase.com/db/abcdef', '-t', 'whocares',
+                          '-o', 'table123', '--tbl-obj', 'bx123sdf'])
+            assert c.realm_hostname == 'example.quickbase.com'
+            assert c.app_id == 'abcdef'
+            assert 'table123' in c.table_ids
+            assert 'bx123sdf' in c.table_ids
+            assert len(c.table_ids) == 2
 
     def test_loads_token_from_environment(self, monkeypatch):
         monkeypatch.setenv('QB_USER_TOKEN', 'foo')

--- a/tests/test_tools/test_model_generate.py
+++ b/tests/test_tools/test_model_generate.py
@@ -123,7 +123,7 @@ class TestModelGenerator:
             monkeypatch.setattr(model_generate.os, 'getcwd', lambda: d)
             c = qbc.main(['run', 'model-generate', '--app-url',
                           'https://example.quickbase.com/db/abcdef', '-t', 'whocares',
-                          '-o', 'table123', '--tbl-obj', 'bx123sdf'])
+                          '-i', 'table123', '--include', 'bx123sdf'])
             assert c.realm_hostname == 'example.quickbase.com'
             assert c.app_id == 'abcdef'
             assert 'table123' in c.table_ids


### PR DESCRIPTION
## Description

As a user with a large QB app who is writing an integration script for just a couple of tables in my app, it doesn't make sense to generate class files for _all_ of the tables in my app. This PR allows users to generate files for only a subset of tables via a new `--include` argument (that can be specified multiple times to allow multiple tables).

An ancillary benefit is to minimise the risk of re-running the script on an existing client (as described in #29). A user could decide to update just a single table if they really need the changes to that table and don't want to risk updating the whole app.

* Adds a `--include` / `-i` argument to the `model-generate` script
* Generates table files for the table(s) specified by the new arg
* Tests and documents new functionality
* Updates pytest to allow passing more args to the `run_generator` fixture

**Checklist:**

- [x] Submitting to `dev` branch
- [x] pytest tests passing
- [x] Includes tests to cover the changes
- [x] flake8 passing
- [x] Relevant documentation added
