### PR TITLE
fix: Don't call `get_fields_for_table` for skipped tables

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -329,6 +329,20 @@ flake8 = ">=3.5"
 pytest = ">=3.5"
 
 [[package]]
+name = "pytest-mock"
+version = "3.6.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "python-dotenv"
 version = "0.15.0"
 description = "Add .env support to your django/flask apps in development and deployments"
@@ -616,7 +630,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "cd082d7190a234a3b2cff230f5b3d3428287e49dd1a7a5c4dc40aceea8a2772d"
+content-hash = "62076f56d4467264ee0fe23203a0817765ea53f9e8164ed3da48a7165ced6da6"
 
 [metadata.files]
 alabaster = [
@@ -827,6 +841,10 @@ pytest-cov = [
 pytest-flake8 = [
     {file = "pytest-flake8-1.0.7.tar.gz", hash = "sha256:f0259761a903563f33d6f099914afef339c085085e643bee8343eb323b32dd6b"},
     {file = "pytest_flake8-1.0.7-py2.py3-none-any.whl", hash = "sha256:c28cf23e7d359753c896745fd4ba859495d02e16c84bac36caa8b1eec58f5bc1"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.6.1.tar.gz", hash = "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"},
+    {file = "pytest_mock-3.6.1-py3-none-any.whl", hash = "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3"},
 ]
 python-dotenv = [
     {file = "python-dotenv-0.15.0.tar.gz", hash = "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Sphinx = "^3.3.0"
 sphinx-rtd-theme = "^0.5.0"
 python-dotenv = "^0.15.0"
 six = "^1.15.0"
+pytest-mock = "^3.6.1"
 
 [tool.poetry.scripts]
 qbc = 'quickbase_client.tools.qbc:main'

--- a/src/quickbase_client/tools/model_generate.py
+++ b/src/quickbase_client/tools/model_generate.py
@@ -161,12 +161,6 @@ class ModelGenerator(Script):
     def add_table_file(self, table, fields):
         table_ident = table['singleRecordName']
         file_name = make_var_name(table_ident)
-        if len(self.table_ids) and not any(
-            x in self.table_ids for x in [table_ident, file_name, table['id']]
-        ):
-            # if table_ids have been specified, and this table's ID, single record name, or var name
-            # is not in the list, skip it
-            return
         if file_name in self.pkg_writer.modules:
             table_ident = table['alias'].replace('_DBID_', '')
             file_name = make_var_name(table_ident)
@@ -196,8 +190,15 @@ class ModelGenerator(Script):
         tables = api.get_tables_for_app(self.app_id)
         for table in tables.json():
             table_id = table['id']
-            fields = api.get_fields_for_table(table_id)
-            self.add_table_file(table, fields.json())
+            table_ident = table['singleRecordName']
+            table_var = make_var_name(table_ident)
+            if not len(self.table_ids) or any(
+                x in self.table_ids for x in [table_var, table_ident, table_id]
+            ):
+                # if not table_ids have been specified, or they have but this table's ID, 
+                # single record name, or var name are in the list, generate it
+                fields = api.get_fields_for_table(table_id)
+                self.add_table_file(table, fields.json())
 
         self.pkg_writer.write()
         return True

--- a/tests/test_tools/test_model_generate.py
+++ b/tests/test_tools/test_model_generate.py
@@ -1,5 +1,6 @@
 import os
 from tempfile import TemporaryDirectory
+from unittest.mock import ANY
 
 import pytest
 from requests import Response
@@ -70,6 +71,12 @@ class TestModelGenerator:
             assert os.path.exists(os.path.join(d, 'qbcpy', 'idea.py'))
             assert os.path.exists(os.path.join(d, 'qbcpy', 'ideas_2.py'))
         run_generator(_asserts, table_ids=['idea', 'cccccc'])
+
+    def test_gets_fields_only_for_requested_tables(self, run_generator, mocker):
+        spy = mocker.spy(model_generate.QuickBaseApiClient, 'get_fields_for_table')
+        run_generator(table_ids=['aaaaaa'])
+        # first arg is `self` because it is an instance method
+        spy.assert_called_once_with(ANY, 'aaaaaa')
 
     def test_writes_table_class(self, run_generator):
         gen = run_generator()


### PR DESCRIPTION
## Description

Though tkutcher/quickbase-client#40 cuts down on the number of files generated, it did not cut down on the number of times fields for tables were requested. This commit moves the "skip" logic to before the`get_fields_for_table` call.

It also adds pytest-mock as a dev dependency in order to test the change.


**Checklist:**

- [x] Submitting to `dev` branch
- [x] pytest tests passing
- [x] Includes tests to cover the changes
- [x] flake8 passing
- [x] Relevant documentation added
